### PR TITLE
Resolve an SELinux AVC message and add some systemd service restrictions

### DIFF
--- a/sbin_update-motd
+++ b/sbin_update-motd
@@ -45,7 +45,7 @@ then
 fi
 
 if [ -d /etc/update-motd.d ]; then
-    TMPFILE=$(mktemp --tmpdir motd.XXXXX)
+    TMPFILE=$(mktemp --tmpdir=/var/lib/update-motd/)
     if [ -f /etc/motd.head ]; then
         cat /etc/motd.head >> $TMPFILE
     fi

--- a/update-motd.service
+++ b/update-motd.service
@@ -10,6 +10,27 @@ ExecStart=/usr/sbin/update-motd
 # update-motd should not be considered active when its processes have exited
 # timer should be able to restart update-motd even after exit
 RemainAfterExit=no
+PrivateTmp=yes
+ProtectHostname=yes
+ProtectHome=yes
+ProtectClock=yes
+RestrictRealtime=yes
+ProtectKernelTunables=yes
+PrivateDevices=yes
+ProtectSystem=full
+SystemCallFilter=~@reboot
+PrivateUsers=yes
+NoNewPrivileges=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+MemoryDenyWriteExecute=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictAddressFamilies=~AF_NETLINK
+RestrictAddressFamilies=~AF_PACKET
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/update-motd.spec
+++ b/update-motd.spec
@@ -1,3 +1,5 @@
+%define _trivial	.0
+%define _buildid	.1
 Name:       update-motd
 Version:    2.1
 Release:    1%{?dist}
@@ -66,6 +68,12 @@ fi
 %ghost /var/lib/update-motd/motd
 
 %changelog
+* Fri Aug 11 2023 Stephen A. Zarkos <szarkos@amazon.com> - 2.1-1.amzn2023.0.1
+- Copy the final $TMPFILE using 'mv -Z' to ensure the motd file inherits
+  the selinux context of the destination directory.
+- Lock down the update-motd.service file to remove unneeded permissions
+  and capabilities.
+
 * Wed Mar 15 2023 Stewart Smith <trawets@amazon.com> 2.1
 - Replace update-motd motd part even when it's zero sized
 - This fixes https://github.com/amazonlinux/amazon-linux-2023/issues/286


### PR DESCRIPTION
- Ensure that $TMPFILE is created in /var/lib/update-motd
  - This allows for an atomic 'mv' operation once the file is generated
  - In addition, it ensures that the motd file inherits the selinux context of the /var/lib/update-motd directory (var_lib_t) instead of /tmp (tmp_t) which sshd and pam_motd.so do not have access to read.
- Lock down the update-motd.service file to remove unneeded permissions and capabilities.

*Issue #, if available:*
N/A

*Description of changes:*
This commit resolves an SELinux AVC denial on Amazon Linux 2023.

In addition, the update-motd service runs with a default set of permissions and capabilities which are not required. So add some restrictions in the update-motd.service file to tune out the permissions that we don't need:

**Before this commit:**
`$ systemd-analyze security update-motd.service`
`→ Overall exposure level for update-motd.service: 9.6 UNSAFE 😨`

**After this commit:**
`$ systemd-analyze security update-motd.service`
`→ Overall exposure level for update-motd.service: 3.5 OK 🙂`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
