### PR TITLE
Fix CPUQuota syntax

### DIFF
--- a/update-motd.service
+++ b/update-motd.service
@@ -37,7 +37,7 @@ StartupCPUWeight=90
 # Run with less priority than other tasks by default
 CPUWeight=50
 # limit to a quarter of a core
-CPUQuota=25
+CPUQuota=25%
 # On startup, limit IO, but not by heaps
 StartupIOWeight=90
 # Run with less priority for IO than other task


### PR DESCRIPTION
Fixes this issue.

```bash
[ssm-user@ip-172-31-144-158 bin]$ sudo journalctl | grep motd
Nov 08 05:41:02 ip-172-31-144-158.us-east-2.compute.internal systemd[1]: /usr/lib/systemd/system/update-motd.service:40: Invalid CPU quota '25', ignoring.
Nov 08 05:42:09 ip-172-31-144-158.us-east-2.compute.internal systemd[1]: /usr/lib/systemd/system/update-motd.service:40: Invalid CPU quota '25', ignoring.
Nov 08 05:54:02 ip-172-31-144-158.us-east-2.compute.internal systemd[1]: /usr/lib/systemd/system/update-motd.service:40: Invalid CPU quota '25', ignoring.
```

reference: `man systemd.resource-control`